### PR TITLE
Update axios.js

### DIFF
--- a/client-mern-blog/src/utils/axios.js
+++ b/client-mern-blog/src/utils/axios.js
@@ -2,6 +2,7 @@ import axios from 'axios'
 
 const instance = axios.create({
     baseURL: 'http://localhost:3002/api',
+    validateStatus: () => true,
 })
 
 instance.interceptors.request.use((config) => {


### PR DESCRIPTION
В случае использования статусов 4xx/5xx в ответах бекэнда, axios останавливает выполнение с ошибкой. Чтобы это предотвратить, ему нужно принудительно указать status=true.